### PR TITLE
fix: update target to match the latest nightly

### DIFF
--- a/armv7a-vex-v5.json
+++ b/armv7a-vex-v5.json
@@ -7,6 +7,7 @@
     "env": "v5",
     "panic-strategy": "abort",
     "relocation-model": "static",
+    "llvm-floatabi": "hard",
     "llvm-target": "armv7a-none-eabihf",
     "features": "+v7,+neon,+vfp3d16,+thumb2",
     "linker": "rust-lld",

--- a/src/targets/armv7a-vex-v5.json
+++ b/src/targets/armv7a-vex-v5.json
@@ -7,6 +7,7 @@
     "env": "v5",
     "panic-strategy": "abort",
     "relocation-model": "static",
+    "llvm-floatabi": "hard",
     "llvm-target": "armv7a-none-eabihf",
     "features": "+v7,+neon,+vfp3d16,+thumb2",
     "linker": "rust-lld",


### PR DESCRIPTION
vexide doesn't build right now using the latest nightly, so this fixes that. I _think_ I did it correctly? I assume that since the llvm target is armv7a-none-eabi<ins>hf</ins> the V5 brain has an FPU.

The template also needs to be updated, but I can't update that repo directly and so I can't build the tar.

See https://github.com/rust-lang/rust/commit/a0dbb3 for why this is needed.