### PR TITLE
feat: differential uploading

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,6 +151,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bidiff"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae58bd32799998ad11ed44ebd9f440a129352883ca082a836d073d8e15d8a9be"
+dependencies = [
+ "byteorder",
+ "divsufsort",
+ "integer-encoding",
+ "log",
+ "rayon",
+ "sacabase",
+ "sacapart",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -220,6 +235,7 @@ checksum = "a33d3b80a8db16c4ad7676653766a8e59b5f95443c8823cb7cff587b90cb91ba"
 name = "cargo-v5"
 version = "0.9.2"
 dependencies = [
+ "bidiff",
  "cargo-subcommand-metadata",
  "cargo_metadata",
  "cfg-if",
@@ -240,6 +256,7 @@ dependencies = [
  "ratatui",
  "reqwest",
  "serde",
+ "serde_ini",
  "serde_json",
  "tabwriter",
  "tar",
@@ -428,6 +445,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "crossterm"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -487,6 +529,15 @@ dependencies = [
  "option-ext",
  "redox_users",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "divsufsort"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e57e36c45fe0b4ef9bc690e53cce2f46dc193f7be3bc93bb7d23ca6dc1be820"
+dependencies = [
+ "sacabase",
 ]
 
 [[package]]
@@ -1026,6 +1077,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "integer-encoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c27df786dcc3a75ccd134f83ece166af0a1e5785d52b12b7375d0d063e1d5c47"
+
+[[package]]
 name = "io-kit-sys"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1521,6 +1578,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1702,6 +1779,26 @@ name = "ryu"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+
+[[package]]
+name = "sacabase"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9883fc3d6ce3d78bb54d908602f8bc1f7b5f983afe601dabe083009d86267a84"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "sacapart"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35d1b03f7f300330cd30da84fea80f64c1d20558c39dc04efbcba7ce52023971"
+dependencies = [
+ "num-traits",
+ "rayon",
+ "sacabase",
+]
 
 [[package]]
 name = "schannel"
@@ -2313,8 +2410,6 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 [[package]]
 name = "vex-v5-serial"
 version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f303c5b98f9ca12a9a681861e983aaa09edc6b49a3b6ba538da66145d5575c0b"
 dependencies = [
  "bitflags 2.6.0",
  "crc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2410,8 +2410,7 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 [[package]]
 name = "vex-v5-serial"
 version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f303c5b98f9ca12a9a681861e983aaa09edc6b49a3b6ba538da66145d5575c0b"
+source = "git+https://github.com/vexide/vex-v5-serial.git#c8c77359acc95b01943574074d83ece35b425ac3"
 dependencies = [
  "bitflags 2.6.0",
  "crc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ fs-err = { version = "3.0.0", features = ["tokio"] }
 cfg-if = "1.0.0"
 inquire = "0.7.5"
 indicatif = "0.17.8"
-vex-v5-serial = { version = "0.3.1", default-features = false, features = [
+vex-v5-serial = { path = "../vex-v5-serial", default-features = false, features = [
     "serial",
 ] }
 tokio = { version = "1.41.0", features = ["full"] }
@@ -54,6 +54,8 @@ chrono = "0.4.38"
 tabwriter = { version = "1.4.0", features = ["ansi_formatting"] }
 humansize = "2.1.3"
 image = { version = "0.25.1", default-features = false, features = ["png"] }
+bidiff = "1.0.0"
+serde_ini = "0.2.0"
 
 [features]
 default = ["clap", "fetch-template"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ fs-err = { version = "3.0.0", features = ["tokio"] }
 cfg-if = "1.0.0"
 inquire = "0.7.5"
 indicatif = "0.17.8"
-vex-v5-serial = { version = "0.3.1", default-features = false, features = [
+vex-v5-serial = { git = "https://github.com/vexide/vex-v5-serial.git", default-features = false, features = [
     "serial",
 ] }
 tokio = { version = "1.41.0", features = ["full"] }

--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -1,4 +1,3 @@
-use log::info;
 use object::{Object, ObjectSegment};
 use std::process::{exit, Stdio};
 use tokio::{process::Command, task::block_in_place};

--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -127,7 +127,6 @@ pub async fn build(
 }
 
 pub async fn objcopy(elf: &Utf8Path) -> Result<Utf8PathBuf, CliError> {
-    info!("Creating binary: {}.bin", elf);
     // Read the ELF file built by cargo.
     let data = tokio::fs::read(elf).await?;
 
@@ -162,6 +161,7 @@ pub async fn objcopy(elf: &Utf8Path) -> Result<Utf8PathBuf, CliError> {
     // Write the binary to a file.
     let bin = elf.with_extension("bin");
     tokio::fs::write(&bin, bytes).await?;
+    println!("     \x1b[1;92mObjcopy\x1b[0m {}", bin);
 
     Ok(bin)
 }

--- a/src/commands/rm.rs
+++ b/src/commands/rm.rs
@@ -5,7 +5,10 @@ use vex_v5_serial::{
         serial::{SerialConnection, SerialError},
         Connection,
     },
-    packets::file::{EraseFilePacket, EraseFilePayload, EraseFileReplyPacket, ExitFileTransferPacket, ExitFileTransferReplyPacket, FileExitAction},
+    packets::file::{
+        EraseFilePacket, EraseFilePayload, EraseFileReplyPacket, ExitFileTransferPacket,
+        ExitFileTransferReplyPacket, FileExitAction,
+    },
     string::FixedString,
 };
 

--- a/src/commands/terminal.rs
+++ b/src/commands/terminal.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use flexi_logger::{LogSpecification, LoggerHandle};
 use log::info;
 use tokio::{
-    io::{stdin, AsyncReadExt},
+    io::{stdin, stdout, AsyncReadExt, AsyncWriteExt},
     select,
     time::sleep,
 };
@@ -22,7 +22,7 @@ pub async fn terminal(connection: &mut SerialConnection, logger: &mut LoggerHand
         select! {
             read = connection.read_user(&mut program_output) => {
                 if let Ok(size) = read {
-                    print!("{}", std::str::from_utf8(&program_output[..size]).unwrap());
+                    stdout().write_all(&program_output[..size]).await.unwrap();
                 }
             },
             read = stdin.read(&mut program_input) => {

--- a/src/commands/upload.rs
+++ b/src/commands/upload.rs
@@ -264,7 +264,7 @@ pub async fn upload_program(
 
                 let patch = build_patch(&old, &new);
 
-                log::debug!(
+                log::info!(
                     "old: {}, new: {}, patch: {}",
                     old.len(),
                     new.len(),
@@ -496,8 +496,8 @@ async fn brain_file_exists(
 ) -> Result<bool, SerialError> {
     match connection
         .packet_handshake::<GetFileMetadataReplyPacket>(
-            Duration::from_millis(500),
-            1,
+            Duration::from_millis(1000),
+            2,
             GetFileMetadataPacket::new(GetFileMetadataPayload {
                 vendor,
                 option: 0,

--- a/src/commands/upload.rs
+++ b/src/commands/upload.rs
@@ -239,7 +239,7 @@ pub async fn upload_program(
             if exists(path.with_extension("base.bin"))?
                 && brain_file_exists(
                     connection,
-                    FixedString::new(slot_file_name.clone()).unwrap(),
+                    FixedString::new(base_file_name.clone()).unwrap(),
                     FileVendor::User,
                 )
                 .await?

--- a/src/commands/upload.rs
+++ b/src/commands/upload.rs
@@ -433,14 +433,14 @@ pub async fn upload_program(
                         },
                         vendor: Some(FileVendor::User),
                         data: {
+                            let mut base_file =
+                                File::create(path.with_file_name(&base_file_name)).await?;
+                            base_file.write_all(&base_data).await?;
+
                             if compress {
                                 gzip_compress(&mut base_data);
                             }
 
-                            // Save base
-                            let mut base_file =
-                                File::create(path.with_file_name(&base_file_name)).await?;
-                            base_file.write_all(&base_data).await?;
                             base_file
                                 .write_all(&VEX_CRC32.checksum(&base_data).to_le_bytes())
                                 .await?;
@@ -511,7 +511,9 @@ fn build_patch(old: &[u8], new: &[u8]) -> Vec<u8> {
     patch.splice(12..12, (old.len() as u32).to_le_bytes());
     patch.splice(16..16, (new.len() as u32).to_le_bytes());
 
+    println!("{}", patch.len());
     gzip_compress(&mut patch);
+    println!("{}", patch.len());
 
     patch
 }

--- a/src/commands/upload.rs
+++ b/src/commands/upload.rs
@@ -67,7 +67,7 @@ pub struct UploadOpts {
     #[arg(long)]
     pub upload_strategy: Option<UploadStrategy>,
 
-    /// Reupload entire base binary if patch uploading.
+    /// Reupload entire base binary if differential uploading.
     #[arg(long)]
     pub cold: bool,
 
@@ -83,8 +83,8 @@ pub enum UploadStrategy {
     #[default]
     Monolith,
 
-    /// Binary patch upload (vexide only)
-    Patch,
+    /// Differential uploads (vexide only)
+    Differential,
 }
 
 /// An action to perform after uploading a program.
@@ -233,7 +233,7 @@ pub async fn upload_program(
             ini_progress.lock().await.finish();
             bin_progress.lock().await.finish();
         }
-        UploadStrategy::Patch => {
+        UploadStrategy::Differential => {
             let base_file_name = format!("slot_{}.base.bin", slot - 1);
 
             if exists(path.with_extension("base.bin"))?

--- a/src/commands/upload.rs
+++ b/src/commands/upload.rs
@@ -511,9 +511,7 @@ fn build_patch(old: &[u8], new: &[u8]) -> Vec<u8> {
     patch.splice(12..12, (old.len() as u32).to_le_bytes());
     patch.splice(16..16, (new.len() as u32).to_le_bytes());
 
-    println!("{}", patch.len());
     gzip_compress(&mut patch);
-    println!("{}", patch.len());
 
     patch
 }

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -46,7 +46,7 @@ async fn is_connection_wireless(connection: &mut SerialConnection) -> Result<boo
         .await?;
     let system_flags = connection
         .packet_handshake::<GetSystemFlagsReplyPacket>(
-            Duration::from_millis(500),
+            Duration::from_millis(5000),
             1,
             GetSystemFlagsPacket::new(()),
         )
@@ -82,7 +82,7 @@ pub async fn switch_radio_channel(
         sleep(Duration::from_millis(250)).await;
 
         // Poll the connection of the controller to ensure the radio has switched channels.
-        let timeout = Duration::from_secs(5);
+        let timeout = Duration::from_secs(8);
         select! {
             _ = sleep(timeout) => {
                 return Err(CliError::RadioChannelTimeout)

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -54,6 +54,13 @@ pub enum CliError {
     )]
     InvalidIcon(String),
 
+    #[error("{0} is not a valid upload strategy.")]
+    #[diagnostic(
+        code(cargo_v5::invalid_upload_strategy),
+        help("See `cargo v5 upload --help` for a list of valid upload strategies.")
+    )]
+    InvalidUploadStrategy(String),
+
     #[error("No slot number was provided.")]
     #[diagnostic(
         code(cargo_v5::no_slot),

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ use cargo_metadata::camino::Utf8PathBuf;
 use cargo_v5::{commands::field_control::run_field_control_tui, errors::CliError};
 use cargo_v5::{
     commands::{
-        build::{build, objcopy, CargoOpts},
+        build::{build, CargoOpts},
         cat::cat,
         devices::devices,
         dir::dir,
@@ -22,7 +22,6 @@ use cargo_v5::{
 use chrono::Utc;
 use clap::{Parser, Subcommand};
 use flexi_logger::{AdaptiveFormat, FileSpec, LogfileSelector, LoggerHandle};
-use tokio::{runtime::Handle, select, task::block_in_place};
 #[cfg(feature = "field-control")]
 use vex_v5_serial::connection::serial::{self, SerialConnection, SerialDevice};
 use vex_v5_serial::{
@@ -157,19 +156,10 @@ async fn app(command: Command, path: Utf8PathBuf, logger: &mut LoggerHandle) -> 
             simulator,
             cargo_opts,
         } => {
-            build(&path, cargo_opts, simulator, |path| {
-                if !simulator {
-                    block_in_place(|| {
-                        Handle::current().block_on(async move {
-                            objcopy(&path).await.unwrap();
-                        });
-                    });
-                }
-            })
-            .await;
+            build(&path, cargo_opts, simulator).await?;
         }
         Command::Upload { upload_opts, after } => {
-            upload(&path, upload_opts, after, &mut open_connection().await?).await?;
+            upload(&path, upload_opts, after).await?;
         }
         Command::Dir => {
             dir(&mut open_connection().await?).await?;
@@ -190,11 +180,9 @@ async fn app(command: Command, path: Utf8PathBuf, logger: &mut LoggerHandle) -> 
             screenshot(&mut open_connection().await?).await?;
         }
         Command::Run(opts) => {
-            let mut connection = open_connection().await?;
+            let mut connection = upload(&path, opts, AfterUpload::Run).await?;
 
-            upload(&path, opts, AfterUpload::Run, &mut connection).await?;
-
-            select! {
+            tokio::select! {
                 () = terminal(&mut connection, logger) => {}
                 _ = tokio::signal::ctrl_c() => {
                     // Quit program

--- a/src/main.rs
+++ b/src/main.rs
@@ -123,7 +123,7 @@ async fn main() -> miette::Result<()> {
     // Parse CLI arguments
     let Cargo::V5 { command, path } = Cargo::parse();
 
-    let mut logger = flexi_logger::Logger::try_with_env_or_str("info")
+    let mut logger = flexi_logger::Logger::try_with_env()
         .unwrap()
         .log_to_file(
             FileSpec::default()

--- a/src/main.rs
+++ b/src/main.rs
@@ -196,17 +196,6 @@ async fn app(command: Command, path: Utf8PathBuf, logger: &mut LoggerHandle) -> 
                         })
                     ).await;
 
-                    // Switch back to pit channel
-                    _ = connection
-                        .packet_handshake::<SelectRadioChannelReplyPacket>(
-                            Duration::from_secs(2),
-                            1,
-                            SelectRadioChannelPacket::new(SelectRadioChannelPayload {
-                                channel: RadioChannel::Pit,
-                            }),
-                        )
-                        .await;
-
                     std::process::exit(0);
                 }
             }


### PR DESCRIPTION
This is the cargo-v5 facing portion of https://github.com/vexide/vexide/pull/269

TODO:
- [x] Compare file CRCs between the base file on the brain and the base file on the host. If they don't match, we need to cold reupload.
- ~~[ ] Cold reupload if the gzipped size of the patch exceeds the gzipped size of the new file.~~ In practice, I think this would take some extreme effort to achieve, so it can be added at a later time.