### PR TITLE
chore: update name in license and copyright date

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 pros-rs
+Copyright (c) 2025 vexide
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Fixes #14.

The license file currently says "(c) 2023 pros-rs", so this PR updates the year and the licensor name.