### PR TITLE
Make version in flake sync with version in Cargo.toml

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -45,7 +45,7 @@
             ] features naersk'.buildPackage {
               name = "cargo-v5";
               pname = "cargo-v5";
-              version = "0.8.2";
+              version = (builtins.fromTOML (builtins.readFile ./Cargo.toml)).package.version;
 
               src = ./.;
 


### PR DESCRIPTION
Updated `build-cargo-v5` in `flake.nix` to set the version of the package to the `Cargo.tml`'s `package.version` property

(The version in the flake was out of date)