### PR TITLE
feat: add --python flag to upload

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -133,4 +133,11 @@ pub enum CliError {
         help("Try creating the project in a different directory or with a different name.")
     )]
     ProjectDirFull(String),
+
+    #[error("Attempted to upload a Python file using the differential upload strategy.")]
+    #[diagnostic(
+        code(cargo_v5::diff_upload_python),
+        help("Differential upload is only supported for binary files with a patcher. Try using the `monolith` upload strategy instead.")
+    )]
+    DiffUploadPython,
 }


### PR DESCRIPTION
This PR adds a `--python` flag to upload Python files. Yay!

It's my impression that cargo-v5 is supposed to be a general-use V5 command line tool like `vexcom` tailored to vexide, so I'm guessing it's okay to add Python support?

Also, I haven't updated the changelog because it looks like it hasn't been updated in a while.