### PR TITLE
fix: update repository URL in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ authors = [
 license = "MIT"
 description = "A cargo subcommand for managing V5 Brain Rust projects"
 homepage = "https://vexide.dev"
-repository = "https://github.com/vexide/cargo-pros"
+repository = "https://github.com/vexide/cargo-v5"
 rust-version = "1.88" # let chains
 
 [package.metadata.v5]


### PR DESCRIPTION
The repository key in Cargo.toml seemed to be pointing to `cargo-pros` (which redirects to `cargo-v5` anyway); I think it might be being used by `cargo-dist` to generate an incorrect install script.