### PR TITLE
feat: actual completions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -315,6 +315,7 @@ dependencies = [
  "cargo_metadata",
  "chrono",
  "clap",
+ "clap_complete",
  "crossterm 0.29.0",
  "diff",
  "directories",
@@ -427,6 +428,18 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
+]
+
+[[package]]
+name = "clap_complete"
+version = "4.5.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39615915e2ece2550c0149addac32fb5bd312c657f43845bb9088cb9c8a7c992"
+dependencies = [
+ "clap",
+ "clap_lex",
+ "is_executable",
+ "shlex",
 ]
 
 [[package]]
@@ -1375,6 +1388,15 @@ name = "is_ci"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7655c9839580ee829dfacba1d1278c2b7883e50a277ff7541299489d6bdfdc45"
+
+[[package]]
+name = "is_executable"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baabb8b4867b26294d818bf3f651a454b6901431711abb96e296245888d6e8c4"
+dependencies = [
+ "windows-sys 0.60.2",
+]
 
 [[package]]
 name = "is_terminal_polyfill"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ rust-version = "1.88" # let chains
 cargo-subcommand-metadata = "0.1.0"
 cargo_metadata = "0.22.0"
 clap = { version = "4.5.40", features = ["derive"], optional = true }
+clap_complete = { version = "4.5.61", features = ["unstable-dynamic"], optional = true }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
 inquire = { version = "0.7.5", default-features = false, features = ["crossterm"] }
@@ -85,7 +86,7 @@ features = [
 
 [features]
 default = ["clap", "field-control", "fetch-template"]
-clap = ["dep:clap"]
+clap = ["dep:clap",  "dep:clap_complete"]
 
 field-control = ["dep:ratatui", "dep:crossterm", "dep:tui-term"]
 fetch-template = ["dep:reqwest", "dep:directories"]

--- a/src/commands/completions.rs
+++ b/src/commands/completions.rs
@@ -1,7 +1,6 @@
 #[cfg(feature = "clap")]
 use std::ffi::OsStr;
-use std::{path::PathBuf};
-use std::ffi::OsString;
+use std::path::PathBuf;
 
 #[cfg(feature = "clap")]
 use clap_complete::engine::{CompletionCandidate, ValueCompleter};
@@ -10,11 +9,8 @@ use directories::ProjectDirs;
 const CACHE_TTL_SECS: u64 = 600; // 10 minutes
 
 fn get_ls_cache_path() -> Option<PathBuf> {
-    dbg!(ProjectDirs::from("", "vexide", "cargo-v5").map(|dirs| {
-        dirs.cache_dir()
-            .to_owned()
-            .join("file-cache.json")
-    }))
+    ProjectDirs::from("", "vexide", "cargo-v5")
+        .map(|dirs| dirs.cache_dir().to_owned().join("file-cache.json"))
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Debug)]
@@ -49,7 +45,7 @@ pub fn write_cache(files: &[String]) {
     };
     if let Ok(content) = serde_json::to_string(&cache) {
         let path = get_ls_cache_path().unwrap();
-    if let Some(parent) = path.parent() {
+        if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent).unwrap();
         }
         let _ = std::fs::write(path, content);

--- a/src/commands/completions.rs
+++ b/src/commands/completions.rs
@@ -27,11 +27,7 @@ fn current_timestamp() -> u64 {
 }
 
 fn read_cache() -> Option<Vec<String>> {
-    let path = if let Some(v) = get_ls_cache_path() {
-        v
-    } else {
-        return None;
-    };
+    let path = get_ls_cache_path()?;
     let content = std::fs::read_to_string(path).ok()?;
     let cache: FileCache = serde_json::from_str(&content).ok()?;
 
@@ -49,9 +45,7 @@ pub fn write_cache(files: &[String]) {
         files: files.to_vec(),
     };
     if let Ok(content) = serde_json::to_string(&cache) {
-        let path = if let Some(v) = get_ls_cache_path() {
-            v
-        } else {
+        let Some(path) = get_ls_cache_path() else {
             return;
         };
         if let Some(parent) = path.parent() {

--- a/src/commands/completions.rs
+++ b/src/commands/completions.rs
@@ -1,0 +1,77 @@
+#[cfg(feature = "clap")]
+use std::ffi::OsStr;
+use std::{path::PathBuf};
+use std::ffi::OsString;
+
+#[cfg(feature = "clap")]
+use clap_complete::engine::{CompletionCandidate, ValueCompleter};
+use directories::ProjectDirs;
+
+const CACHE_TTL_SECS: u64 = 600; // 10 minutes
+
+fn get_ls_cache_path() -> Option<PathBuf> {
+    dbg!(ProjectDirs::from("", "vexide", "cargo-v5").map(|dirs| {
+        dirs.cache_dir()
+            .to_owned()
+            .join("file-cache.json")
+    }))
+}
+
+#[derive(serde::Serialize, serde::Deserialize, Debug)]
+struct FileCache {
+    timestamp: u64,
+    files: Vec<String>,
+}
+
+fn current_timestamp() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+fn read_cache() -> Option<Vec<String>> {
+    let content = std::fs::read_to_string(get_ls_cache_path().unwrap()).ok()?;
+    let cache: FileCache = serde_json::from_str(&content).ok()?;
+
+    if current_timestamp() - cache.timestamp < CACHE_TTL_SECS {
+        Some(cache.files)
+    } else {
+        None
+    }
+}
+
+/// Writes the file list cache. Called by `cargo v5 ls`.
+pub fn write_cache(files: &[String]) {
+    let cache = FileCache {
+        timestamp: current_timestamp(),
+        files: files.to_vec(),
+    };
+    if let Ok(content) = serde_json::to_string(&cache) {
+        let path = get_ls_cache_path().unwrap();
+    if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        let _ = std::fs::write(path, content);
+    }
+}
+
+#[cfg(feature = "clap")]
+pub struct FileCompleter;
+
+#[cfg(feature = "clap")]
+impl ValueCompleter for FileCompleter {
+    fn complete(&self, current: &OsStr) -> Vec<CompletionCandidate> {
+        let Some(files) = read_cache() else {
+            return Vec::new();
+        };
+
+        let current_str = current.to_string_lossy();
+
+        files
+            .into_iter()
+            .filter(|file| file.starts_with(&*current_str))
+            .map(CompletionCandidate::new)
+            .collect()
+    }
+}

--- a/src/commands/dir.rs
+++ b/src/commands/dir.rs
@@ -63,11 +63,14 @@ pub async fn dir(connection: &mut SerialConnection) -> Result<(), CliError> {
         .await
         .unwrap();
 
+    let mut entries = Vec::new();
+
     write!(
         &mut tw,
         "\x1B[1mName\tSize\tLoad Address\tVendor\tType\tTimestamp\tVersion\tCRC32\n\x1B[0m"
     )
     .unwrap();
+
     for vid in USEFUL_VIDS {
         let file_count = connection
             .handshake::<DirectoryFileCountReplyPacket>(
@@ -92,7 +95,7 @@ pub async fn dir(connection: &mut SerialConnection) -> Result<(), CliError> {
                 )
                 .await?
                 .payload?;
-
+            entries.push(format!("{}{}", vendor_prefix(vid), &entry.file_name));
             writeln!(
                 &mut tw,
                 "{}{}\t{}\t{}\t{:?}\t{}\t{}\t{}\t{}",
@@ -142,6 +145,8 @@ pub async fn dir(connection: &mut SerialConnection) -> Result<(), CliError> {
     }
 
     tw.flush().unwrap();
+
+    super::completions::write_cache(&entries);
 
     Ok(())
 }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,5 +1,6 @@
 pub mod build;
 pub mod cat;
+pub mod completions;
 pub mod devices;
 pub mod dir;
 #[cfg(feature = "field-control")]

--- a/src/commands/new.rs
+++ b/src/commands/new.rs
@@ -57,8 +57,8 @@ async fn fetch_template() -> Result<Template, CliError> {
 async fn get_cached_template() -> Option<Template> {
     match cached_template_dir() {
         Some(dir) => {
-            let cache_file = dir.with_file_name(TEMPLATE_FILE_NAME);
-            let sha_file = dir.with_file_name(SHA_FILE_NAME);
+            let cache_file = dir.join(TEMPLATE_FILE_NAME);
+            let sha_file = dir.join(SHA_FILE_NAME);
             let sha = tokio::fs::read_to_string(sha_file).await.ok();
             let data = tokio::fs::read(cache_file).await.ok();
             data.map(|data| Template { data, sha })
@@ -70,8 +70,8 @@ async fn get_cached_template() -> Option<Template> {
 #[cfg(feature = "fetch-template")]
 async fn store_cached_template(template: Template) -> () {
     if let Some(dir) = cached_template_dir() {
-        let cache_file = dir.with_file_name(TEMPLATE_FILE_NAME);
-        let sha_file = dir.with_file_name(SHA_FILE_NAME);
+        let cache_file = dir.join(TEMPLATE_FILE_NAME);
+        let sha_file = dir.join(SHA_FILE_NAME);
         let _ = tokio::fs::write(cache_file, &template.data).await;
         if let Some(sha) = template.sha {
             let _ = tokio::fs::write(sha_file, sha).await;

--- a/src/commands/rm.rs
+++ b/src/commands/rm.rs
@@ -24,8 +24,9 @@ pub async fn rm(connection: &mut SerialConnection, files: Vec<PathBuf>) -> Resul
             ""
         });
 
-        let file_name = FixedString::from_str(file.file_name().unwrap_or_default().to_str().unwrap())
-            .map_err(|err| CliError::SerialError(SerialError::FixedStringSizeError(err)))?;
+        let file_name =
+            FixedString::from_str(file.file_name().unwrap_or_default().to_str().unwrap())
+                .map_err(|err| CliError::SerialError(SerialError::FixedStringSizeError(err)))?;
 
         connection
             .handshake::<FileEraseReplyPacket>(

--- a/src/main.rs
+++ b/src/main.rs
@@ -100,7 +100,7 @@ enum Command {
     },
     /// Erase a file from flash.
     Rm {
-        file: PathBuf,
+        files: Vec<PathBuf>,
     },
     /// Read a Brain's event log.
     Log {
@@ -175,7 +175,7 @@ async fn app(command: Command, path: PathBuf, logger: &mut LoggerHandle) -> miet
         Command::Dir => dir(&mut open_connection().await?).await?,
         Command::Devices => devices(&mut open_connection().await?).await?,
         Command::Cat { file } => cat(&mut open_connection().await?, file).await?,
-        Command::Rm { file } => rm(&mut open_connection().await?, file).await?,
+        Command::Rm { files } => rm(&mut open_connection().await?, files).await?,
         Command::Log { page } => log(&mut open_connection().await?, page).await?,
         Command::Screenshot => screenshot(&mut open_connection().await?).await?,
         Command::Run(opts) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ use cargo_v5::{
     commands::{
         build::{CargoOpts, build},
         cat::cat,
+        completions::FileCompleter,
         devices::devices,
         dir::dir,
         log::log,
@@ -11,15 +12,14 @@ use cargo_v5::{
         terminal::terminal,
         upgrade,
         upload::{AfterUpload, UploadOpts, upload},
-        completions::FileCompleter
     },
     connection::{open_connection, switch_to_download_channel},
     errors::CliError,
     self_update::{self, SelfUpdateMode},
 };
-use clap_complete::ArgValueCompleter;
 use chrono::Utc;
 use clap::{Args, CommandFactory, Parser, Subcommand};
+use clap_complete::ArgValueCompleter;
 use flexi_logger::{AdaptiveFormat, FileSpec, LogfileSelector, LoggerHandle};
 use std::{env, num::NonZeroU32, panic, path::PathBuf};
 use vex_v5_serial::{

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,13 +11,15 @@ use cargo_v5::{
         terminal::terminal,
         upgrade,
         upload::{AfterUpload, UploadOpts, upload},
+        completions::FileCompleter
     },
     connection::{open_connection, switch_to_download_channel},
     errors::CliError,
     self_update::{self, SelfUpdateMode},
 };
+use clap_complete::ArgValueCompleter;
 use chrono::Utc;
-use clap::{Args, Parser, Subcommand};
+use clap::{Args, CommandFactory, Parser, Subcommand};
 use flexi_logger::{AdaptiveFormat, FileSpec, LogfileSelector, LoggerHandle};
 use std::{env, num::NonZeroU32, panic, path::PathBuf};
 use vex_v5_serial::{
@@ -96,10 +98,12 @@ enum Command {
     Dir,
     /// Read a file from flash, then write its contents to stdout.
     Cat {
+        #[cfg_attr(feature = "clap", arg(add = ArgValueCompleter::new(FileCompleter)))]
         file: PathBuf,
     },
     /// Erase a file from flash.
     Rm {
+        #[cfg_attr(feature = "clap", arg(add = ArgValueCompleter::new(FileCompleter)))]
         files: Vec<PathBuf>,
     },
     /// Read a Brain's event log.
@@ -133,6 +137,8 @@ struct DownloadOpts {
 
 #[tokio::main]
 async fn main() -> miette::Result<()> {
+    clap_complete::env::CompleteEnv::with_factory(|| Cargo::command()).complete();
+
     // Parse CLI arguments
     let Cargo::V5 { command, path } = Cargo::parse();
 


### PR DESCRIPTION
**important:** this is [stacked](https://www.stacking.dev/) on top of #31, that needs to be reviewed/merged first

written by clawd 🦀 

to test (this is zsh but it should be similar for other systems):
```bash
cargo install --path .
autoload -Uz compinit; compinit; source <(COMPLETE=zsh cargo-v5)
cargo v5 cat <tab>
cargo v5 rm <tab>
```

