### PR TITLE
feat: add C compilation support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,7 +120,6 @@ checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
 [[package]]
 name = "arm-toolchain"
 version = "0.1.0"
-source = "git+https://github.com/vexide/arm-toolchain#5f14c4b233da897d091f77cd0e616fe496201a90"
 dependencies = [
  "camino",
  "clap",
@@ -327,6 +326,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "bon"
+version = "3.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebeb9aaf9329dff6ceb65c689ca3db33dbf15f324909c60e4e5eef5701ce31b1"
+dependencies = [
+ "bon-macros",
+ "rustversion",
+]
+
+[[package]]
+name = "bon-macros"
+version = "3.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77e9d642a7e3a318e37c2c9427b5a6a48aa1ad55dcd986f3034ab2239045a645"
+dependencies = [
+ "darling 0.21.3",
+ "ident_case",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
+
+[[package]]
 name = "borsh"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -421,6 +445,7 @@ dependencies = [
  "arm-toolchain",
  "axoupdater",
  "bidiff",
+ "bon",
  "cargo-subcommand-metadata",
  "cargo_metadata 0.22.0",
  "chrono",
@@ -829,8 +854,18 @@ version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
+dependencies = [
+ "darling_core 0.21.3",
+ "darling_macro 0.21.3",
 ]
 
 [[package]]
@@ -848,12 +883,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
- "darling_core",
+ "darling_core 0.20.11",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
+dependencies = [
+ "darling_core 0.21.3",
  "quote",
  "syn",
 ]
@@ -1758,7 +1818,7 @@ version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6778b0196eefee7df739db78758e5cf9b37412268bfa5650bfeed028aed20d9c"
 dependencies = [
- "darling",
+ "darling 0.20.11",
  "indoc",
  "proc-macro2",
  "quote",
@@ -2602,6 +2662,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,6 +120,7 @@ checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
 [[package]]
 name = "arm-toolchain"
 version = "0.1.0"
+source = "git+https://github.com/vexide/arm-toolchain#406a0dc646de369bf4ffdbb82330b79d0c58ac18"
 dependencies = [
  "camino",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,7 +120,7 @@ checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
 [[package]]
 name = "arm-toolchain"
 version = "0.1.0"
-source = "git+https://github.com/vexide/arm-toolchain#53aab0f5da623d16c09f9544291fc80f8c67c951"
+source = "git+https://github.com/vexide/arm-toolchain#5f14c4b233da897d091f77cd0e616fe496201a90"
 dependencies = [
  "camino",
  "clap",
@@ -635,9 +635,9 @@ checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
 name = "convert_case"
-version = "0.7.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb402b8d4c85569410425650ce3eddc7d698ed96d39a73f941b08fb63082f1e7"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
 dependencies = [
  "unicode-segmentation",
 ]
@@ -903,22 +903,23 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
-version = "2.0.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
+checksum = "10b768e943bed7bf2cab53df09f4bc34bfd217cdb57d971e769874c9a6710618"
 dependencies = [
  "derive_more-impl",
 ]
 
 [[package]]
 name = "derive_more-impl"
-version = "2.0.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
+checksum = "6d286bfdaf75e988b4a78e013ecd79c581e06399ab53fbacd2d916c2f904f30b"
 dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
+ "rustc_version",
  "syn",
 ]
 
@@ -1529,9 +1530,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52e9a2a24dc5c6821e71a7030e1e14b7b632acac55c40e9d2e082c621261bb56"
+checksum = "727805d60e7938b76b826a6ef209eb70eaa1812794f9424d4a4e2d740662df5f"
 dependencies = [
  "base64",
  "bytes",
@@ -1898,9 +1899,9 @@ checksum = "2c4a545a15244c7d945065b5d392b2d2d7f21526fba56ce51467b06ed445e8f7"
 
 [[package]]
 name = "libc"
-version = "0.2.177"
+version = "0.2.178"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
+checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
 
 [[package]]
 name = "liblzma"
@@ -2009,9 +2010,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.28"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lru"
@@ -2110,9 +2111,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69d83b0086dc8ecf3ce9ae2874b2d1290252e2a30720bea58a5c6639b0092873"
+checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
  "log",
@@ -4851,18 +4852,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.30"
+version = "0.8.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ea879c944afe8a2b25fef16bb4ba234f47c694565e97383b36f3a878219065c"
+checksum = "fd74ec98b9250adb3ca554bdde269adf631549f51d8a8f8f0a10b50f1cb298c3"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.30"
+version = "0.8.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf955aa904d6040f70dc8e9384444cb1030aed272ba3cb09bbc4ab9e7c1f34f5"
+checksum = "d8a8d209fdf45cf5138cbb5a506f6b52522a25afccc534d1475dad8e31105c6a"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -92,10 +103,69 @@ dependencies = [
 ]
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
+name = "arc-swap"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
+
+[[package]]
+name = "arm-toolchain"
+version = "0.1.0"
+source = "git+https://github.com/vexide/arm-toolchain#53aab0f5da623d16c09f9544291fc80f8c67c951"
+dependencies = [
+ "camino",
+ "clap",
+ "data-encoding",
+ "directories",
+ "dmg",
+ "fs-err",
+ "futures",
+ "humansize",
+ "indicatif",
+ "inquire",
+ "liblzma",
+ "miette",
+ "octocrab",
+ "owo-colors",
+ "reqwest",
+ "scopeguard",
+ "sha2",
+ "strum 0.27.2",
+ "tar",
+ "tempfile",
+ "thiserror",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "trash",
+ "zip",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "atomic-waker"
@@ -194,10 +264,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64ct"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
 
 [[package]]
 name = "bidiff"
@@ -234,6 +316,15 @@ name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "borsh"
@@ -273,6 +364,15 @@ name = "bytes"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+
+[[package]]
+name = "bzip2"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a53fac24f34a81bc9954b5d6cfce0c21e18ec6959f44f56e8e90e4bb7c346c"
+dependencies = [
+ "libbz2-rs-sys",
+]
 
 [[package]]
 name = "camino"
@@ -318,10 +418,11 @@ dependencies = [
 name = "cargo-v5"
 version = "0.12.1"
 dependencies = [
+ "arm-toolchain",
  "axoupdater",
  "bidiff",
  "cargo-subcommand-metadata",
- "cargo_metadata",
+ "cargo_metadata 0.22.0",
  "chrono",
  "clap",
  "crossterm 0.29.0",
@@ -371,6 +472,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "cargo_metadata"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef987d17b0a113becdd19d3d0022d04d7ef41f9efe4f3fb63ac44ba61df3ade9"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
 name = "cassowary"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -392,6 +507,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c481bdbf0ed3b892f6f806287d72acd515b352a4ec27a208489b8c1bc839633a"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -414,8 +531,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
 dependencies = [
  "iana-time-zone",
+ "js-sys",
  "num-traits",
+ "serde",
+ "wasm-bindgen",
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
 ]
 
 [[package]]
@@ -492,6 +622,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "constant_time_eq"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
+
+[[package]]
 name = "convert_case"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -521,6 +663,15 @@ name = "countme"
 version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7704b5fdd17b18ae31c4c1da5a2e0305a2bf17b5249300a9ee9ed7b72114c636"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "crc"
@@ -582,29 +733,13 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crossterm"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e64e6c0fbe2c17357405f7c758c1ef960fce08bdfb2c03d88d2a18d7e09c4b67"
-dependencies = [
- "bitflags 1.3.2",
- "crossterm_winapi",
- "libc",
- "mio 0.8.11",
- "parking_lot",
- "signal-hook",
- "signal-hook-mio",
- "winapi",
-]
-
-[[package]]
-name = "crossterm"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
  "bitflags 2.10.0",
  "crossterm_winapi",
- "mio 1.1.0",
+ "mio",
  "parking_lot",
  "rustix 0.38.44",
  "signal-hook",
@@ -622,7 +757,7 @@ dependencies = [
  "crossterm_winapi",
  "derive_more",
  "document-features",
- "mio 1.1.0",
+ "mio",
  "parking_lot",
  "rustix 1.1.2",
  "signal-hook",
@@ -637,6 +772,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -675,6 +859,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
+
+[[package]]
+name = "deflate64"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26bf8fc351c5ed29b5c2f0cbbac1b209b74f60ecd62e675a998df72c49af5204"
+
+[[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "derive_more"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -700,6 +927,18 @@ name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "const-oid",
+ "crypto-common",
+ "subtle",
+]
 
 [[package]]
 name = "directories"
@@ -743,6 +982,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dmg"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abc28c350337837f23b4750f774371f63db232338c9f89bdb9eb48523a7c4722"
+dependencies = [
+ "log",
+ "plist",
+]
+
+[[package]]
 name = "document-features"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -764,10 +1013,69 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
+]
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "serde",
+ "sha2",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest",
+ "ff",
+ "generic-array",
+ "group",
+ "hkdf",
+ "pem-rfc7468",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "encode_unicode"
@@ -818,6 +1126,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
 name = "filetime"
 version = "0.2.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -842,6 +1166,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfe33edd8e85a12a67454e37f8c75e730830d83e313556ab9ebf9ee7fbeb3bfb"
 dependencies = [
  "crc32fast",
+ "libz-rs-sys",
  "miniz_oxide",
 ]
 
@@ -979,12 +1304,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "fxhash"
-version = "0.2.1"
+name = "fuzzy-matcher"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+checksum = "54614a3312934d066701a80f20f15fa3b56d67ac7722b39eea5b4c9dd1d66c94"
 dependencies = [
- "byteorder",
+ "thread_local",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
+dependencies = [
+ "typenum",
+ "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -1021,6 +1357,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1050,6 +1397,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "homedir"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1058,7 +1423,7 @@ dependencies = [
  "cfg-if",
  "nix 0.30.1",
  "widestring",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -1139,12 +1504,27 @@ dependencies = [
  "http",
  "hyper",
  "hyper-util",
+ "log",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
  "webpki-roots",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -1349,19 +1729,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "inquire"
-version = "0.7.5"
+name = "inout"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fddf93031af70e75410a2511ec04d49e758ed2f26dad3404a934e0fb45cc12a"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "inquire"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2628910d0114e9139056161d8644a2026be7b117f8498943f9437748b04c9e0a"
 dependencies = [
  "bitflags 2.10.0",
- "crossterm 0.25.0",
+ "crossterm 0.29.0",
  "dyn-clone",
- "fxhash",
- "newline-converter",
- "once_cell",
+ "fuzzy-matcher",
  "unicode-segmentation",
- "unicode-width 0.1.14",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]
@@ -1446,6 +1833,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
 name = "jod-thread"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1462,16 +1859,68 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonwebtoken"
+version = "10.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c76e1c7d7df3e34443b3621b459b066a7b79644f059fc8b2db7070c825fd417e"
+dependencies = [
+ "base64",
+ "ed25519-dalek",
+ "getrandom 0.2.16",
+ "hmac",
+ "js-sys",
+ "p256",
+ "p384",
+ "pem",
+ "rand 0.8.5",
+ "rsa",
+ "serde",
+ "serde_json",
+ "sha2",
+ "signature",
+ "simple_asn1",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
+
+[[package]]
+name = "libbz2-rs-sys"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c4a545a15244c7d945065b5d392b2d2d7f21526fba56ce51467b06ed445e8f7"
 
 [[package]]
 name = "libc"
 version = "0.2.177"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
+
+[[package]]
+name = "liblzma"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73c36d08cad03a3fbe2c4e7bb3a9e84c57e4ee4135ed0b065cade3d98480c648"
+dependencies = [
+ "liblzma-sys",
+]
+
+[[package]]
+name = "liblzma-sys"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01b9596486f6d60c3bbe644c0e1be1aa6ccc472ad630fe8927b456973d7cb736"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
 
 [[package]]
 name = "libm"
@@ -1508,6 +1957,15 @@ checksum = "3c8469b4a23b962c1396b9b451dda50ef5b283e8dd309d69033475fa9b334324"
 dependencies = [
  "libc",
  "pkg-config",
+]
+
+[[package]]
+name = "libz-rs-sys"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b484ba8d4f775eeca644c452a56650e544bf7e617f1d170fe7298122ead5222"
+dependencies = [
+ "zlib-rs",
 ]
 
 [[package]]
@@ -1569,6 +2027,16 @@ name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "lzma-rust2"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c60a23ffb90d527e23192f1246b14746e2f7f071cb84476dd879071696c18a4a"
+dependencies = [
+ "crc",
+ "sha2",
+]
 
 [[package]]
 name = "mach2"
@@ -1642,18 +2110,6 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
-dependencies = [
- "libc",
- "log",
- "wasi",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "mio"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69d83b0086dc8ecf3ce9ae2874b2d1290252e2a30720bea58a5c6639b0092873"
@@ -1671,7 +2127,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "029e1f407e261176a983a6599c084efd322d9301028055c87174beac71397ba3"
 dependencies = [
  "log",
- "mio 1.1.0",
+ "mio",
  "nix 0.29.0",
  "serialport",
  "winapi",
@@ -1694,15 +2150,6 @@ checksum = "80986bbbcf925ebd3be54c26613d861255284584501595cf418320c078945608"
 dependencies = [
  "num-traits",
  "pxfm",
-]
-
-[[package]]
-name = "newline-converter"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b6b097ecb1cbfed438542d16e84fd7ad9b0c76c8a65b7f9039212a3d14dc7f"
-dependencies = [
- "unicode-segmentation",
 ]
 
 [[package]]
@@ -1750,12 +2197,90 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint-dig"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+dependencies = [
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.5",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
+]
+
+[[package]]
+name = "objc2"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c2599ce0ec54857b29ce62166b0ed9b4f6f1a70ccc9a71165b6154caca8c05"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags 2.10.0",
+ "objc2",
 ]
 
 [[package]]
@@ -1765,6 +2290,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "octocrab"
+version = "0.48.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5930b376c98c438a4f4259a760cda2c198efea3b82de8f8a2aff0c00a8b7c1c"
+dependencies = [
+ "arc-swap",
+ "async-trait",
+ "base64",
+ "bytes",
+ "cargo_metadata 0.23.1",
+ "cfg-if",
+ "chrono",
+ "either",
+ "futures",
+ "futures-util",
+ "getrandom 0.2.16",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-timeout",
+ "hyper-util",
+ "jsonwebtoken",
+ "once_cell",
+ "percent-encoding",
+ "pin-project",
+ "secrecy",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "snafu",
+ "tokio",
+ "tower",
+ "tower-http",
+ "tracing",
+ "url",
+ "web-time",
 ]
 
 [[package]]
@@ -1802,6 +2369,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1821,6 +2394,30 @@ name = "owo-colors"
 version = "4.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c6901729fa79e91a0913333229e9ca5dc725089d1c363b2f4b4760709dc4a52"
+
+[[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
+
+[[package]]
+name = "p384"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
 
 [[package]]
 name = "parking_lot"
@@ -1852,10 +2449,59 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest",
+ "hmac",
+]
+
+[[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64",
+ "serde_core",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pin-project"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -1870,10 +2516,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "plist"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
+dependencies = [
+ "base64",
+ "indexmap",
+ "quick-xml",
+ "time",
+]
 
 [[package]]
 name = "png"
@@ -1904,12 +2583,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "ppmd-rust"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d558c559f0450f16f2a27a1f017ef38468c1090c9ce63c8e51366232d53717b4"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
 ]
 
 [[package]]
@@ -1928,6 +2628,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3502d6155304a4173a5f2c34b52b7ed0dd085890326cb50fd625fdf39e86b3b"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.38.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1959,7 +2668,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand",
+ "rand 0.9.2",
  "ring",
  "rustc-hash 2.1.1",
  "rustls",
@@ -2067,12 +2776,33 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2082,7 +2812,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.3",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.16",
 ]
 
 [[package]]
@@ -2109,7 +2848,7 @@ dependencies = [
  "itertools 0.13.0",
  "lru",
  "paste",
- "strum",
+ "strum 0.26.3",
  "unicode-segmentation",
  "unicode-truncate",
  "unicode-width 0.2.0",
@@ -2193,6 +2932,7 @@ dependencies = [
  "base64",
  "bytes",
  "futures-core",
+ "futures-util",
  "http",
  "http-body",
  "http-body-util",
@@ -2212,14 +2952,26 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "webpki-roots",
+]
+
+[[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
 ]
 
 [[package]]
@@ -2250,6 +3002,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "rsa"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40a0376c50d0358279d9d643e4bf7b7be212f1f4ff1da9070a7b54d22ef75c88"
+dependencies = [
+ "const-oid",
+ "digest",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2272,6 +3044,15 @@ name = "rustc-literal-escaper"
 version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab03008eb631b703dd16978282ae36c73282e7922fe101a4bd072a40ecea7b8b"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rustix"
@@ -2305,12 +3086,25 @@ version = "0.23.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "533f54bc6a7d4f647e46ad909549eda97bf5afc1585190ef692b4286b198bd8f"
 dependencies = [
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9980d917ebb0c0536119ba501e90834767bffc3d60641457fd84a1f3fd337923"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -2376,10 +3170,65 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "secrecy"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3297343eaf830f66ede390ea39da1d462b6b0c1b000f420d0a83f898bbbe6ef"
+dependencies = [
+ "bitflags 2.10.0",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "self-replace"
@@ -2468,6 +3317,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2509,6 +3369,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2531,8 +3413,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
 dependencies = [
  "libc",
- "mio 0.8.11",
- "mio 1.1.0",
+ "mio",
  "signal-hook",
 ]
 
@@ -2546,10 +3427,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest",
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
+
+[[package]]
+name = "simple_asn1"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "297f631f50729c8c99b84667867963997ec0b50f32b2a7dbcab828ef0541e8bb"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror",
+ "time",
+]
 
 [[package]]
 name = "slab"
@@ -2574,6 +3477,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "snafu"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e84b3f4eacbf3a1ce05eac6763b4d629d60cbc94d632e4092c54ade71f1e1a2"
+dependencies = [
+ "snafu-derive",
+]
+
+[[package]]
+name = "snafu-derive"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "socket2"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2581,6 +3505,22 @@ checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
 dependencies = [
  "libc",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
 ]
 
 [[package]]
@@ -2607,7 +3547,16 @@ version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.26.4",
+]
+
+[[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+dependencies = [
+ "strum_macros 0.27.2",
 ]
 
 [[package]]
@@ -2620,6 +3569,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
+ "syn",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
  "syn",
 ]
 
@@ -2780,6 +3741,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "time"
+version = "0.3.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
+
+[[package]]
+name = "time-macros"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2812,7 +3813,7 @@ checksum = "ff360e02eab121e0bc37a2d3b4d4dc622e6eda3a8e5253d5435ecf5bd4c68408"
 dependencies = [
  "bytes",
  "libc",
- "mio 1.1.0",
+ "mio",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
@@ -2852,6 +3853,19 @@ dependencies = [
  "log",
  "mio-serial",
  "serialport",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2efa149fe76073d6e8fd97ef4f4eca7b67f599660115591483572e406e165594"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
  "tokio",
 ]
 
@@ -2944,8 +3958,10 @@ dependencies = [
  "pin-project-lite",
  "sync_wrapper",
  "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -2964,6 +3980,7 @@ dependencies = [
  "tower",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -2984,6 +4001,7 @@ version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d15d90a0b5c19378952d479dc858407149d7bb45a14de0142f6c534b16fc647"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -3007,6 +4025,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a04e24fab5c89c6a36eb8558c9656f30d81de51dfa4d3b45f26b21d61fa0a6c"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "trash"
+version = "5.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9b93a14fcf658568eb11b3ac4cb406822e916e2c55cdebc421beeb0bd7c94d8"
+dependencies = [
+ "chrono",
+ "libc",
+ "log",
+ "objc2",
+ "objc2-foundation",
+ "once_cell",
+ "percent-encoding",
+ "scopeguard",
+ "urlencoding",
+ "windows 0.56.0",
 ]
 
 [[package]]
@@ -3036,6 +4072,12 @@ name = "typeid"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
+
+[[package]]
+name = "typenum"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
 name = "unescaper"
@@ -3124,6 +4166,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3134,6 +4182,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vex-cdc"
@@ -3287,6 +4341,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3303,6 +4370,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
+ "serde",
  "wasm-bindgen",
 ]
 
@@ -3354,6 +4422,16 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1de69df01bdf1ead2f4ac895dc77c9351aefff65b2f3db429a343f9cbf05e132"
+dependencies = [
+ "windows-core 0.56.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows"
 version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
@@ -3376,12 +4454,24 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4698e52ed2d08f8658ab0c39512a7c00ee5fe2688c65f8c0a4f06750d729f2a6"
+dependencies = [
+ "windows-implement 0.56.0",
+ "windows-interface 0.56.0",
+ "windows-result 0.1.2",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
  "windows-link 0.1.3",
  "windows-result 0.3.4",
  "windows-strings 0.4.2",
@@ -3393,8 +4483,8 @@ version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
  "windows-link 0.2.1",
  "windows-result 0.4.1",
  "windows-strings 0.5.1",
@@ -3413,9 +4503,31 @@ dependencies = [
 
 [[package]]
 name = "windows-implement"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6fc35f58ecd95a9b71c4f2329b911016e6bec66b3f2e6a4aad86bd2e99e2f9b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08990546bf4edef8f431fa6326e032865f27138718c587dc21bc0265bbcb57cc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3457,6 +4569,15 @@ dependencies = [
 
 [[package]]
 name = "windows-result"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-result"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
@@ -3493,15 +4614,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -3534,21 +4646,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link 0.2.1",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -3595,12 +4692,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -3613,12 +4704,6 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -3628,12 +4713,6 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3661,12 +4740,6 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -3676,12 +4749,6 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3697,12 +4764,6 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -3712,12 +4773,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -3840,6 +4895,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zerotrie"
@@ -3872,4 +4941,77 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "zip"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2a05c7c36fde6c09b08576c9f7fb4cda705990f73b58fe011abf7dfb24168b"
+dependencies = [
+ "aes",
+ "arbitrary",
+ "bzip2",
+ "constant_time_eq",
+ "crc32fast",
+ "deflate64",
+ "flate2",
+ "getrandom 0.3.4",
+ "hmac",
+ "indexmap",
+ "lzma-rust2",
+ "memchr",
+ "pbkdf2",
+ "ppmd-rust",
+ "sha1",
+ "time",
+ "zeroize",
+ "zopfli",
+ "zstd",
+]
+
+[[package]]
+name = "zlib-rs"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36134c44663532e6519d7a6dfdbbe06f6f8192bde8ae9ed076e9b213f0e31df7"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ cargo_metadata = "0.22.0"
 clap = { version = "4.5.40", features = ["derive"], optional = true }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
-inquire = { version = "0.7.5", default-features = false, features = ["crossterm"] }
+inquire = { version = "0.9.1", default-features = false, features = ["crossterm"] }
 indicatif = "0.18.0"
 vex-v5-serial = { version = "0.5.2", default-features = false, features = [
     "serial",
@@ -63,6 +63,7 @@ fs-err = { version = "3.1.2", features = ["tokio"] }
 diff = "0.1.13"
 semver = "1.0.27"
 ra_ap_syntax = "0.0.305"
+arm-toolchain = { git = "https://github.com/vexide/arm-toolchain", version = "0.1.0" }
 
 [dependencies.syntect]
 version = "5.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,9 @@ fs-err = { version = "3.1.2", features = ["tokio"] }
 diff = "0.1.13"
 semver = "1.0.27"
 ra_ap_syntax = "0.0.305"
-arm-toolchain = { git = "https://github.com/vexide/arm-toolchain", version = "0.1.0" }
+# arm-toolchain = { git = "https://github.com/vexide/arm-toolchain", version = "0.1.0" }
+arm-toolchain = { path = "../arm-toolchain" }
+bon = "3.8.1"
 
 [dependencies.syntect]
 version = "5.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,8 +63,7 @@ fs-err = { version = "3.1.2", features = ["tokio"] }
 diff = "0.1.13"
 semver = "1.0.27"
 ra_ap_syntax = "0.0.305"
-# arm-toolchain = { git = "https://github.com/vexide/arm-toolchain", version = "0.1.0" }
-arm-toolchain = { path = "../arm-toolchain" }
+arm-toolchain = { git = "https://github.com/vexide/arm-toolchain", version = "0.1.0" }
 bon = "3.8.1"
 
 [dependencies.syntect]

--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -17,7 +17,10 @@ use tokio::{
 };
 
 use crate::{
-    commands::toolchain::ToolchainCmd, errors::CliError, fs, settings::{Settings, ToolchainCfg, ToolchainType}
+    commands::toolchain::ToolchainCmd,
+    errors::CliError,
+    fs,
+    settings::{Settings, ToolchainCfg, ToolchainType},
 };
 
 /// Common Cargo options to forward.
@@ -90,9 +93,9 @@ pub async fn build(
 
     // If there is a toolchain enabled, we need to put it in scope so that cc builds work correctly.
 
-    let toolchain = root_settings
-        .and_then(|s| s.toolchain.as_ref())
-        .or(toolchain.as_ref());
+    let toolchain = toolchain
+        .as_ref()
+        .or(root_settings.and_then(|s| s.toolchain.as_ref()));
 
     if let Some(toolchain_cfg) = toolchain {
         let ToolchainType::LLVM = toolchain_cfg.ty;
@@ -172,10 +175,7 @@ pub async fn build(
             .collect::<Vec<String>>();
 
         let mut rust_flags = link_flags;
-        rust_flags.push(format!(
-            "'--cfg=vexide_toolchain=\"{}\"'",
-            toolchain_cfg.ty
-        ));
+        rust_flags.push(format!("'--cfg=vexide_toolchain=\"{}\"'", toolchain_cfg.ty));
 
         // N.B. It's okay if the `target.<cfg>.rustflags` key is a duplicate to one in
         // the cargo config, they will still merge as expected.

--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -84,7 +84,7 @@ pub async fn build(
         .any(|arg| arg == "--target" || arg.starts_with("--target="));
 
     if !explicit_target_specified {
-        build_cmd.args(["--target=armv7a-vex-v5"]);
+        build_cmd.arg("--target=armv7a-vex-v5");
     }
 
     // If there is a toolchain enabled, we need to put it in scope so that cc builds work correctly.

--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -104,7 +104,7 @@ pub async fn build(
         // If no toolchain installed, ask user to install it now. If they say "no",
         // the `run()` call will return an error that we just propagate.
         if matches!(toolchain, Err(ToolchainError::ToolchainNotInstalled { .. })) {
-            ToolchainCmd::Install.run().await?;
+            ToolchainCmd::install(&client, toolchain_cfg).await?;
             toolchain = client.toolchain(&toolchain_cfg.version).await;
         }
         let toolchain = toolchain?;

--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -12,7 +12,7 @@ use std::{
     process::{Stdio, exit},
 };
 use tokio::{
-    io::{AsyncBufReadExt, AsyncWriteExt, BufReader},
+    io::{AsyncBufReadExt, BufReader},
     process::Command,
 };
 

--- a/src/commands/migrate/source_code.rs
+++ b/src/commands/migrate/source_code.rs
@@ -47,7 +47,10 @@ pub async fn update_targets(ctx: &mut ChangesCtx, metadata: &Metadata) -> Result
                 continue;
             }
 
-            ctx.describe(format!("Enabled importing from the Standard Library (for {})", target.name));
+            ctx.describe(format!(
+                "Enabled importing from the Standard Library (for {})",
+                target.name
+            ));
 
             // Removing nodes can leave the line they are on, so remove any prefixed whitespace.
             let trimmed_len = new_contents.len() - new_contents.trim_start().len();

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -12,3 +12,4 @@ pub mod terminal;
 pub mod migrate;
 pub mod upload;
 pub mod key_value;
+pub mod toolchain;

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -4,12 +4,12 @@ pub mod devices;
 pub mod dir;
 #[cfg(feature = "field-control")]
 pub mod field_control;
+pub mod key_value;
 pub mod log;
+pub mod migrate;
 pub mod new;
 pub mod rm;
 pub mod screenshot;
 pub mod terminal;
-pub mod migrate;
-pub mod upload;
-pub mod key_value;
 pub mod toolchain;
+pub mod upload;

--- a/src/commands/toolchain.rs
+++ b/src/commands/toolchain.rs
@@ -1,0 +1,55 @@
+use arm_toolchain::{cli::{confirm_install, ctrl_c_cancel, install_with_progress_bar}, toolchain::ToolchainClient};
+use owo_colors::OwoColorize;
+
+use crate::{errors::CliError, metadata::{Metadata, ToolchainType}};
+
+#[derive(Debug, clap::Subcommand)]
+pub enum ToolchainCmd {
+    Install,
+}
+
+impl ToolchainCmd {
+    pub async fn run(self) -> Result<(), CliError> {
+        let client = ToolchainClient::using_data_dir().await?;
+        let metadata = Metadata::for_root().await?;
+
+        match self {
+            Self::Install => Self::install(client, metadata).await,
+        }
+    }
+
+    async fn install(client: ToolchainClient, metadata: Option<Metadata>) -> Result<(), CliError> {
+        let Some(metadata) = metadata else {
+            return Err(CliError::NoCargoProject);
+        };
+        let Some(cfg) = metadata.toolchain else {
+            return Err(CliError::NoToolchainConfigured);
+        };
+
+        let ty = cfg.ty;
+        let ToolchainType::LLVM = ty;
+
+        let version = cfg.version;
+
+        let already_installed = client.install_path_for(&version);
+        if already_installed.exists() {
+            println!(
+                "Toolchain already installed: {}",
+                format!("{ty:?} {version}").bold(),
+            );
+            return Ok(());
+        }
+
+        let release = client.get_release(&version).await?;
+
+        confirm_install(&version, false).await?;
+
+        let token = ctrl_c_cancel();
+        install_with_progress_bar(&client, &release, token.clone()).await?;
+        token.cancel();
+
+        println!("Toolchain {} is ready for use.", format!("{ty:?} {version}").bold());
+
+        Ok(())
+    }
+}

--- a/src/commands/toolchain.rs
+++ b/src/commands/toolchain.rs
@@ -19,7 +19,7 @@ impl ToolchainCmd {
         let client = ToolchainClient::using_data_dir().await?;
 
         let metadata = workspace_metadata().await;
-        let settings = Settings::for_root(metadata.as_ref())?;
+        let settings = Settings::load(metadata.as_ref(), None)?;
 
         match self {
             Self::Install => {

--- a/src/commands/toolchain.rs
+++ b/src/commands/toolchain.rs
@@ -1,7 +1,13 @@
-use arm_toolchain::{cli::{confirm_install, ctrl_c_cancel, install_with_progress_bar}, toolchain::ToolchainClient};
+use arm_toolchain::{
+    cli::{confirm_install, ctrl_c_cancel, install_with_progress_bar},
+    toolchain::ToolchainClient,
+};
 use owo_colors::OwoColorize;
 
-use crate::{errors::CliError, metadata::{Metadata, ToolchainType}};
+use crate::{
+    errors::CliError,
+    metadata::{Metadata, ToolchainType},
+};
 
 #[derive(Debug, clap::Subcommand)]
 pub enum ToolchainCmd {
@@ -48,7 +54,10 @@ impl ToolchainCmd {
         install_with_progress_bar(&client, &release, token.clone()).await?;
         token.cancel();
 
-        println!("Toolchain {} is ready for use.", format!("{ty:?} {version}").bold());
+        println!(
+            "Toolchain {} is ready for use.",
+            format!("{ty:?} {version}").bold()
+        );
 
         Ok(())
     }

--- a/src/commands/upload.rs
+++ b/src/commands/upload.rs
@@ -40,7 +40,7 @@ use crate::{
     settings::Settings,
 };
 
-use super::build::{CargoOpts, build};
+use super::build::{BuildOpts, build};
 
 /// Options used to control the behavior of a program upload
 #[derive(Args, Debug)]
@@ -77,9 +77,9 @@ pub struct UploadOpts {
     #[arg(long)]
     pub cold: bool,
 
-    /// Arguments forwarded to `cargo`.
+    /// Arguments forwarded to `cargo`, and other build options.
     #[clap(flatten)]
-    pub cargo_opts: CargoOpts,
+    pub build_opts: BuildOpts,
 }
 
 /// Method used for uploading binaries
@@ -586,7 +586,7 @@ pub async fn upload(
         description,
         icon,
         uncompressed,
-        cargo_opts,
+        build_opts: cargo_opts,
         upload_strategy,
         cold,
     }: UploadOpts,

--- a/src/commands/upload.rs
+++ b/src/commands/upload.rs
@@ -1,3 +1,5 @@
+use bon::builder;
+use cargo_metadata::Metadata;
 use clap::{Args, ValueEnum};
 use flate2::{Compression, GzBuilder};
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
@@ -5,10 +7,9 @@ use inquire::{
     CustomType,
     validator::{ErrorMessage, Validation},
 };
-use tokio::{fs::File, io::AsyncWriteExt, sync::Mutex, task::block_in_place, time::Instant};
+use tokio::{fs::File, io::AsyncWriteExt, sync::Mutex, time::Instant};
 
 use std::{
-    ffi::OsStr,
     io::{ErrorKind, Write},
     path::{Path, PathBuf},
     sync::Arc,
@@ -33,12 +34,13 @@ use vex_v5_serial::{
 };
 
 use crate::{
+    commands::build::objcopy_path,
     connection::{open_connection, switch_to_download_channel},
     errors::CliError,
-    metadata::Metadata,
+    settings::Settings,
 };
 
-use super::build::{CargoOpts, build, objcopy};
+use super::build::{CargoOpts, build};
 
 /// Options used to control the behavior of a program upload
 #[derive(Args, Debug)]
@@ -156,9 +158,10 @@ pub const PROGRESS_CHARS: &str = "⣿⣦⣀";
 const DIFFERENTIAL_UPLOAD_MAX_SIZE: usize = 0x200000;
 
 /// Upload a program to the brain.
+#[builder]
 pub async fn upload_program(
-    connection: &mut SerialConnection,
-    path: &Path,
+    #[builder(start_fn)] connection: &mut SerialConnection,
+    #[builder(start_fn)] path: &Path,
     after: AfterUpload,
     slot: u8,
     name: String,
@@ -205,7 +208,7 @@ description={}",
     if needs_ini_upload {
         let ini_timestamp = Arc::new(Mutex::new(None));
         // Progress bars
-        let ini_progress = Arc::new(Mutex::new(
+        let ini_progress =
             multi_progress
                 .add(ProgressBar::new(10000))
                 .with_style(
@@ -215,8 +218,7 @@ description={}",
                     .unwrap() // Okay to unwrap, since this just validates style formatting.
                     .progress_chars(PROGRESS_CHARS),
                 )
-                .with_message(ini_file_name.clone()),
-        ));
+                .with_message(ini_file_name.clone());
 
         connection
             .execute_command(UploadFile {
@@ -245,7 +247,7 @@ description={}",
             })
             .await?;
 
-        ini_progress.lock().await.finish();
+        ini_progress.finish();
     }
 
     match upload_strategy {
@@ -254,18 +256,16 @@ description={}",
             // which unfortunately requires us to juggle timestamps across threads.
             let bin_timestamp = Arc::new(Mutex::new(None));
 
-            let bin_progress = Arc::new(Mutex::new(
-                multi_progress
-                    .add(ProgressBar::new(10000))
-                    .with_style(
-                        ProgressStyle::with_template(
-                            "   \x1b[1;96mUploading\x1b[0m {percent_precise:>7}% {bar:40.red} {msg} ({prefix})",
-                        )
-                        .unwrap() // Okay to unwrap, since this just validates style formatting.
-                        .progress_chars(PROGRESS_CHARS),
+            let bin_progress = multi_progress
+                .add(ProgressBar::new(10000))
+                .with_style(
+                    ProgressStyle::with_template(
+                        "\x1b[1;96mUploading\x1b[0m  {percent_precise:>7}% {bar:40.red} {msg} ({prefix})",
                     )
-                    .with_message(slot_file_name.clone()),
-            ));
+                    .unwrap() // Okay to unwrap, since this just validates style formatting.
+                    .progress_chars(PROGRESS_CHARS),
+                )
+                .with_message(slot_file_name.clone());
 
             // Upload the program.
             connection
@@ -307,8 +307,7 @@ description={}",
                 })
                 .await?;
 
-            // Tell the progressbars that we're done once uploading is complete, allowing further messages to be printed to stdout.
-            bin_progress.lock().await.finish();
+            bin_progress.finish();
         }
         UploadStrategy::Differential => {
             let base_file_name = format!("slot_{slot}.base.bin");
@@ -349,7 +348,7 @@ description={}",
             if !needs_cold_upload {
                 let base = base.unwrap();
                 let patch_timestamp = Arc::new(Mutex::new(None));
-                let patch_progress = Arc::new(Mutex::new(
+                let patch_progress =
                     multi_progress
                         .add(ProgressBar::new(10000))
                         .with_style(
@@ -359,8 +358,7 @@ description={}",
                             .unwrap() // Okay to unwrap, since this just validates style formatting.
                             .progress_chars(PROGRESS_CHARS),
                         )
-                        .with_message(slot_file_name.clone()),
-                ));
+                        .with_message(slot_file_name.clone());
 
                 let new = tokio::fs::read(path).await?;
 
@@ -412,13 +410,13 @@ description={}",
                     })
                     .await?;
 
-                patch_progress.lock().await.finish();
+                patch_progress.finish();
             } else {
                 // indicatif is a little dumb with timestamp handling, so we're going to do this all custom,
                 // which unfortunately requires us to juggle timestamps across threads.
                 let base_timestamp = Arc::new(Mutex::new(None));
 
-                let base_progress = Arc::new(Mutex::new(
+                let base_progress =
                     multi_progress
                         .add(ProgressBar::new(10000))
                         .with_style(
@@ -428,8 +426,7 @@ description={}",
                             .unwrap() // Okay to unwrap, since this just validates style formatting.
                             .progress_chars(PROGRESS_CHARS),
                         )
-                        .with_message(base_file_name.clone()),
-                ));
+                        .with_message(base_file_name.clone());
 
                 let mut base_data = tokio::fs::read(path).await?;
 
@@ -477,7 +474,7 @@ description={}",
                         )),
                     })
                     .await?;
-                base_progress.lock().await.finish();
+                base_progress.finish();
 
                 connection
                     .execute_command(UploadFile {
@@ -559,11 +556,10 @@ async fn brain_file_metadata(
 }
 
 fn build_progress_callback(
-    progress: Arc<Mutex<ProgressBar>>,
+    progress: ProgressBar,
     timestamp: Arc<Mutex<Option<Instant>>>,
 ) -> Box<dyn FnMut(f32) + Send> {
     Box::new(move |percent| {
-        let progress = progress.try_lock().unwrap();
         let mut timestamp = timestamp.try_lock().unwrap();
 
         if timestamp.is_none() {
@@ -595,74 +591,67 @@ pub async fn upload(
         cold,
     }: UploadOpts,
     after: AfterUpload,
+    metadata: Option<Metadata>,
 ) -> miette::Result<SerialConnection> {
-    // Try to open a serialport in the background while we build.
-    let (mut connection, (artifact, package_id)) = tokio::try_join!(
-        async {
-            let mut connection = open_connection().await?;
+    // Try to open a serial port in the background while we build.
+    let conn_fut = async {
+        let mut connection = open_connection().await?;
 
-            // Switch the radio to the download channel if the controller is wireless.
-            switch_to_download_channel(&mut connection).await?;
+        // Switch the radio to the download channel if the controller is wireless.
+        switch_to_download_channel(&mut connection).await?;
 
-            Ok::<SerialConnection, CliError>(connection)
-        },
-        async {
-            // Get the build artifact we'll be uploading with.
-            //
-            // The user either directly passed an file through the `--file` argument, or they didn't and we need to run
-            // `cargo build`.
-            Ok(if let Some(file) = file {
-                if file.extension() == Some(OsStr::new("bin")) {
-                    (file, None)
-                } else {
-                    // If a BIN file wasn't provided, we'll attempt to objcopy it as if it were an ELF.
-                    let binary =
-                        objcopy(&tokio::fs::read(&file).await.map_err(CliError::IoError)?)?;
-                    let binary_path = file.with_extension("bin");
+        Ok::<SerialConnection, CliError>(connection)
+    };
 
-                    // Write the binary to a file.
-                    tokio::fs::write(&binary_path, binary)
-                        .await
-                        .map_err(CliError::IoError)?;
-                    eprintln!("     \x1b[1;92mObjcopy\x1b[0m {}", binary_path.display());
+    let artifact_fut = async {
+        // Get the build artifact we'll be uploading with.
+        //
+        // The user either directly passed an file through the `--file` argument, or they didn't and we need to run
+        // `cargo build`.
+        if let Some(path) = file {
+            // The user directly passed a file through the `--file` argument, so there's
+            // no need to build anything. We may need to objcopy though.
 
-                    (binary_path, None)
-                }
-            } else {
-                // Run cargo build, then objcopy.
-                build(path, cargo_opts)
-                    .await?
-                    .map(|output| (output.bin_artifact, Some(output.package_id)))
-                    .ok_or(CliError::NoArtifact)?
-            })
+            let (path, _) = objcopy_path(&path).await?;
+            return Ok((path, None));
         }
-    )?;
 
-    // We'll use `cargo-metadata` to parse the output of `cargo metadata` and find valid `Cargo.toml`
-    // files in the workspace directory.
-    let cargo_metadata =
-        block_in_place(|| cargo_metadata::MetadataCommand::new().no_deps().exec()).ok();
+        // No file was explicitly passed, so we'll just build and see what Cargo gives us to work with.
+
+        let root_settings = Settings::for_root(metadata.as_ref())?;
+        let Some(output) = build(path, cargo_opts, root_settings.as_ref()).await? else {
+            return Err(CliError::NoArtifact);
+        };
+        Ok((output.bin_artifact, Some(output.package_id)))
+    };
+
+    let (mut connection, build) = tokio::try_join!(conn_fut, artifact_fut)?;
+    let (artifact, package_id) = build;
 
     // Find which package we're being built from, if we're being built from a package at all.
-    let package = cargo_metadata.and_then(|metadata| {
+    let package = metadata.and_then(|metadata| {
         package_id
             .as_ref()
             .and_then(|id| metadata.packages.iter().find(|p| &p.id == id))
-            .or_else(|| metadata.workspace_packages().first().copied())
+            .or_else(|| metadata.root_package())
             .cloned()
     });
 
     // Uploading has the option to use the `package.metadata.v5` table for default configuration options.
-    // Attempt to serialize `package.metadata.v5` into a [`Metadata`] struct. This will just Default::default to
+    // Attempt to serialize `package.metadata.v5` into a [`Settings`] struct. This will just Default::default to
     // all `None`s if it can't find a specific field, or error if the field is malformed.
-    let metadata = package.as_ref().map(Metadata::from_pkg).transpose()?;
+    let settings = package
+        .as_ref()
+        .map(Settings::from_pkg)
+        .transpose()?
+        .unwrap_or_default();
 
     // The program's slot number is absolutely required for uploading. If the slot argument isn't directly provided:
     //
     // - Check for the `package.metadata.v5.slot` field in Cargo.toml.
     // - If that doesn't exist, directly prompt the user asking what slot to upload to.
     let slot = slot
-        .or(metadata.as_ref().and_then(|m| m.slot))
+        .or(settings.slot)
         .or_else(|| {
             CustomType::<u8>::new("Choose a program slot to upload to:")
                 .with_validator(|slot: &u8| {
@@ -684,34 +673,32 @@ pub async fn upload(
     }
 
     // Pass information to the upload routine.
-    upload_program(
-        &mut connection,
-        &artifact,
-        after,
-        slot,
-        name.or(package.as_ref().map(|pkg| pkg.name.to_string()))
-            .unwrap_or("cargo-v5".to_string()),
-        description
-            .or(package.as_ref().and_then(|pkg| pkg.description.clone()))
-            .unwrap_or("Uploaded with cargo-v5.".to_string()),
-        icon.or(metadata.as_ref().and_then(|metadata| metadata.icon))
-            .unwrap_or_default(),
-        "Rust".to_string(), // `program_type` hardcoded for now, maybe configurable in the future.
-        match uncompressed {
+    upload_program(&mut connection, &artifact)
+        .after(after)
+        .slot(slot)
+        .name(
+            name.or(package.as_ref().map(|pkg| pkg.name.to_string()))
+                .unwrap_or("cargo-v5".to_string()),
+        )
+        .description(
+            description
+                .or(package.as_ref().and_then(|pkg| pkg.description.clone()))
+                .unwrap_or("Uploaded with cargo-v5.".to_string()),
+        )
+        .icon(icon.or(settings.icon).unwrap_or_default())
+        .program_type("Rust".to_string()) // `program_type` hardcoded for now, maybe configurable in the future.
+        .compress(match uncompressed {
             Some(val) => !val,
-            None => metadata
-                .as_ref()
-                .and_then(|metadata| metadata.compress)
-                .unwrap_or(true),
-        },
-        cold,
-        upload_strategy
-            .or(metadata
-                .as_ref()
-                .and_then(|metadata| metadata.upload_strategy))
-            .unwrap_or_default(),
-    )
-    .await?;
+            None => settings.compress.unwrap_or(true),
+        })
+        .cold(cold)
+        .upload_strategy(
+            upload_strategy
+                .or(settings.upload_strategy)
+                .unwrap_or_default(),
+        )
+        .call()
+        .await?;
 
     Ok(connection)
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -7,7 +7,7 @@ use miette::Diagnostic;
 use thiserror::Error;
 use vex_v5_serial::protocol::{FixedStringSizeError, cdc2::Cdc2Ack};
 
-use crate::{commands::migrate::MigrateError, metadata::BadFieldDataError};
+use crate::{commands::migrate::MigrateError, settings::BadFieldDataError};
 
 #[non_exhaustive]
 #[derive(Error, Diagnostic, Debug)]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -7,7 +7,7 @@ use miette::Diagnostic;
 use thiserror::Error;
 use vex_v5_serial::protocol::{FixedStringSizeError, cdc2::Cdc2Ack};
 
-use crate::commands::migrate::MigrateError;
+use crate::{commands::migrate::MigrateError, metadata::BadFieldDataError};
 
 #[non_exhaustive]
 #[derive(Error, Diagnostic, Debug)]
@@ -47,6 +47,10 @@ pub enum CliError {
     Inquire(#[from] InquireError),
 
     #[error(transparent)]
+    #[diagnostic(transparent)]
+    ArmToolchainError(#[from] arm_toolchain::toolchain::ToolchainError),
+
+    #[error(transparent)]
     #[diagnostic(code(cargo_v5::fixed_string_size_error))]
     FixedStringSizeError(#[from] FixedStringSizeError),
 
@@ -54,7 +58,7 @@ pub enum CliError {
     #[error("Incorrect type for field `{field}` (expected {expected}, found {found}).")]
     #[diagnostic(
         code(cargo_v5::bad_field_type),
-        help("The `{field}` field should be of type {expected}.")
+        help("Update Cargo.toml to fix the invalid cargo-v5 metadata.")
     )]
     BadFieldType {
         /// Field name
@@ -66,6 +70,13 @@ pub enum CliError {
         /// Actual type
         found: String,
     },
+
+    #[error("Failed to parse cargo-v5 metadata")]
+    #[diagnostic(
+        code(cargo_v5::bad_field_data),
+        help("Update Cargo.toml to fix the invalid metadata.")
+    )]
+    BadFieldData(#[from] BadFieldDataError),
 
     // TODO: Add optional source spans.
     #[error("The provided slot should be in the range [1, 8] inclusive.")]
@@ -199,4 +210,25 @@ pub enum CliError {
         help("Try running a cold upload using `cargo v5 upload --cold`.")
     )]
     PatchTooLarge(usize),
+
+    #[error("This command must be run in a Cargo workspace")]
+    #[diagnostic(code(cargo_v5::cargo_workspace_missing))]
+    NoCargoProject,
+
+    #[error("No toolchains are configured for this project")]
+    #[diagnostic(
+        code(cargo_v5::no_toolchains_configured),
+        help("Set `package.metadata.v5.toolchain` to a toolchain version in Cargo.toml")
+    )]
+    NoToolchainConfigured,
+}
+
+impl From<arm_toolchain::cli::CliError> for CliError {
+    fn from(value: arm_toolchain::cli::CliError) -> Self {
+        match value {
+            arm_toolchain::cli::CliError::Toolchain(t) => t.into(),
+            arm_toolchain::cli::CliError::Inquire(i) => i.into(),
+            other => panic!("{other}"),
+        }
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,7 @@
+pub(crate) use fs_err::tokio as fs;
+
 pub mod commands;
 pub mod connection;
 pub mod errors;
-pub mod metadata;
+pub mod settings;
 pub mod self_update;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,18 @@
 use cargo_v5::{
     commands::{
-        build::{CargoOpts, build}, cat::cat, devices::devices, dir::dir, key_value::{kv_get, kv_set}, log::log, migrate, new::new, rm::rm, screenshot::screenshot, terminal::terminal, toolchain::ToolchainCmd, upload::{AfterUpload, UploadOpts, upload}
+        build::{CargoOpts, build},
+        cat::cat,
+        devices::devices,
+        dir::dir,
+        key_value::{kv_get, kv_set},
+        log::log,
+        migrate,
+        new::new,
+        rm::rm,
+        screenshot::screenshot,
+        terminal::terminal,
+        toolchain::ToolchainCmd,
+        upload::{AfterUpload, UploadOpts, upload},
     },
     connection::{open_connection, switch_to_download_channel},
     errors::CliError,
@@ -103,14 +115,10 @@ enum Command {
     Dir,
 
     /// Read a file from flash, then write its contents to stdout.
-    Cat {
-        file: PathBuf,
-    },
+    Cat { file: PathBuf },
 
     /// Erase a file from flash.
-    Rm {
-        file: PathBuf,
-    },
+    Rm { file: PathBuf },
 
     /// Read a Brain's event log.
     Log {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,17 +1,6 @@
 use cargo_v5::{
     commands::{
-        build::{CargoOpts, build},
-        cat::cat,
-        devices::devices,
-        dir::dir,
-        key_value::{kv_get, kv_set},
-        log::log,
-        new::new,
-        rm::rm,
-        screenshot::screenshot,
-        terminal::terminal,
-        migrate,
-        upload::{AfterUpload, UploadOpts, upload},
+        build::{CargoOpts, build}, cat::cat, devices::devices, dir::dir, key_value::{kv_get, kv_set}, log::log, migrate, new::new, rm::rm, screenshot::screenshot, terminal::terminal, toolchain::ToolchainCmd, upload::{AfterUpload, UploadOpts, upload}
     },
     connection::{open_connection, switch_to_download_channel},
     errors::CliError,
@@ -74,7 +63,7 @@ enum Command {
         #[clap(flatten)]
         cargo_opts: CargoOpts,
     },
-    
+
     /// Upload a project or file to a Brain.
     #[clap(visible_alias = "u")]
     Upload {
@@ -84,15 +73,15 @@ enum Command {
         #[clap(flatten)]
         upload_opts: UploadOpts,
     },
-    
+
     /// Access a Brain's remote terminal I/O.
     #[clap(visible_alias = "t")]
     Terminal,
-    
+
     /// Build, upload, and run a program on a V5 Brain, showing its output in the terminal.
     #[clap(visible_alias = "r")]
     Run(UploadOpts),
-    
+
     /// Create a new vexide project with a given name.
     #[clap(visible_alias = "n")]
     New {
@@ -102,17 +91,17 @@ enum Command {
         #[clap(flatten)]
         download_opts: DownloadOpts,
     },
-    
+
     /// Create a new vexide project in the current directory.
     Init {
         #[clap(flatten)]
         download_opts: DownloadOpts,
     },
-    
+
     /// List files on flash.
     #[clap(visible_alias = "ls")]
     Dir,
-    
+
     /// Read a file from flash, then write its contents to stdout.
     Cat {
         file: PathBuf,
@@ -122,13 +111,13 @@ enum Command {
     Rm {
         file: PathBuf,
     },
-    
+
     /// Read a Brain's event log.
     Log {
         #[arg(long, short, default_value = "1")]
         page: NonZeroU32,
     },
-    
+
     /// List devices connected to a Brain.
     #[clap(visible_alias = "lsdev")]
     Devices,
@@ -136,22 +125,26 @@ enum Command {
     /// Take a screen capture of the brain, saving the file to the current directory.
     #[clap(visible_alias = "sc")]
     Screenshot,
-    
+
     /// Access a Brain's system key/value configuration.
     #[command(subcommand, visible_alias = "kv")]
     KeyValue(KeyValue),
-    
+
     /// Run a field control TUI.
     #[cfg(feature = "field-control")]
     #[clap(visible_aliases = ["fc", "comp-control"])]
     FieldControl,
-    
+
     /// Update cargo-v5 to the latest version.
     #[clap(hide = matches!(*self_update::CURRENT_MODE, SelfUpdateMode::Unmanaged(_)))]
     SelfUpdate,
 
     /// Migrate an older project to vexide 0.8.0.
     Migrate,
+
+    /// Manage additional toolchains for vexide projects.
+    #[command(subcommand)]
+    Toolchain(ToolchainCmd),
 }
 
 #[derive(Args, Debug)]
@@ -284,6 +277,9 @@ async fn app(command: Command, path: PathBuf, logger: &mut LoggerHandle) -> miet
         }
         Command::Migrate => {
             migrate::migrate_workspace(&path).await?;
+        }
+        Command::Toolchain(toolchain) => {
+            toolchain.run().await?;
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 use cargo_v5::{
     commands::{
-        build::{CargoOpts, build},
+        build::{BuildOpts, build},
         cat::cat,
         devices::devices,
         dir::dir,
@@ -74,7 +74,7 @@ enum Command {
     Build {
         /// Arguments forwarded to `cargo`.
         #[clap(flatten)]
-        cargo_opts: CargoOpts,
+        cargo_opts: BuildOpts,
     },
 
     /// Upload a project or file to a Brain.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 use cargo_v5::{
     commands::{
-        build::{BuildOpts, build},
+        build::{BuildOpts, build, find_project_override},
         cat::cat,
         devices::devices,
         dir::dir,
@@ -201,7 +201,8 @@ async fn app(command: Command, path: PathBuf, logger: &mut LoggerHandle) -> miet
     match command {
         Command::Build { cargo_opts } => {
             let metadata = workspace_metadata().await;
-            let settings = Settings::for_root(metadata.as_ref())?;
+            let project = find_project_override(&cargo_opts.args);
+            let settings = Settings::load(metadata.as_ref(), project)?;
 
             build(&path, cargo_opts, settings.as_ref()).await?;
         }

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -1,6 +1,11 @@
-use cargo_metadata::Package;
+use std::str::FromStr;
+
+use arm_toolchain::toolchain::ToolchainVersion;
+use cargo_metadata::{Package, PackageId};
 use clap::ValueEnum;
 use serde_json::Value;
+use thiserror::Error;
+use tokio::task::{block_in_place, spawn_blocking};
 
 use crate::{
     commands::upload::{ProgramIcon, UploadStrategy},
@@ -18,16 +23,30 @@ fn field_type(field: &Value) -> &'static str {
     }
 }
 
-#[derive(Default, Debug, Clone, Copy, Eq, PartialEq)]
+#[derive(Default, Debug, Clone, Eq, PartialEq)]
 pub struct Metadata {
     pub slot: Option<u8>,
     pub icon: Option<ProgramIcon>,
     pub compress: Option<bool>,
     pub upload_strategy: Option<UploadStrategy>,
+    pub toolchain: Option<ToolchainCfg>,
 }
 
 impl Metadata {
-    pub fn new(pkg: &Package) -> Result<Self, CliError> {
+    pub async fn for_root() -> Result<Option<Self>, CliError> {
+        let Ok(metadata) =
+            spawn_blocking(|| cargo_metadata::MetadataCommand::new().no_deps().exec())
+                .await
+                .unwrap()
+        else {
+            return Ok(None);
+        };
+
+        let root_package = metadata.root_package();
+        root_package.map(Self::from_pkg).transpose()
+    }
+
+    pub fn from_pkg(pkg: &Package) -> Result<Self, CliError> {
         if let Some(metadata) = pkg.metadata.as_object()
             && let Some(v5_metadata) = metadata.get("v5").and_then(|m| m.as_object())
         {
@@ -82,9 +101,65 @@ impl Metadata {
                 } else {
                     None
                 },
+                toolchain: if let Some(toolchain) = v5_metadata.get("toolchain") {
+                    let str = toolchain.as_str().ok_or(CliError::BadFieldType {
+                        field: "toolchain".to_string(),
+                        expected: "table".to_string(),
+                        found: field_type(toolchain).to_string(),
+                    })?;
+
+                    Some(ToolchainCfg::from_str(str)?)
+                } else {
+                    None
+                },
             });
         }
 
         Ok(Self::default())
     }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct ToolchainCfg {
+    pub ty: ToolchainType,
+    pub version: ToolchainVersion,
+}
+
+impl FromStr for ToolchainCfg {
+    type Err = BadFieldDataError;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let Some((left, right)) = s.split_once('-') else {
+            return Err(BadFieldDataError::ToolchainMissingDash);
+        };
+
+        let ty = ToolchainType::from_str(left)?;
+        let version = ToolchainVersion::from(right);
+
+        Ok(Self { ty, version })
+    }
+}
+
+#[derive(Default, Debug, Clone, Eq, PartialEq)]
+pub enum ToolchainType {
+    #[default]
+    LLVM,
+}
+
+impl FromStr for ToolchainType {
+    type Err = BadFieldDataError;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let lower = s.to_lowercase();
+        match &*s {
+            "llvm" => Ok(Self::LLVM),
+            _ => Err(BadFieldDataError::ToolchainTypeUnsupported { request: lower }),
+        }
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum BadFieldDataError {
+    #[error("The `toolchain` type {request:?} is not supported [allowed values: llvm]")]
+    ToolchainTypeUnsupported { request: String },
+    #[error("`toolchain`s must have a type and version separated by a dash (e.g. llvm-21.1.1)")]
+    ToolchainMissingDash,
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,7 +1,7 @@
 use std::{fmt::{Display, Formatter}, str::FromStr};
 
 use arm_toolchain::toolchain::ToolchainVersion;
-use cargo_metadata::{Metadata, Package, PackageId};
+use cargo_metadata::{Metadata, Package};
 use clap::ValueEnum;
 use serde_json::Value;
 use thiserror::Error;
@@ -147,7 +147,7 @@ impl FromStr for ToolchainType {
     type Err = BadFieldDataError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let lower = s.to_lowercase();
-        match &*s {
+        match s {
             "llvm" => Ok(Self::LLVM),
             _ => Err(BadFieldDataError::ToolchainTypeUnsupported { request: lower }),
         }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -137,7 +137,7 @@ impl FromStr for ToolchainCfg {
     }
 }
 
-#[derive(Default, Debug, Clone, Eq, PartialEq)]
+#[derive(Default, Debug, Clone, Copy, Eq, PartialEq)]
 pub enum ToolchainType {
     #[default]
     LLVM,

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,4 +1,4 @@
-use std::str::FromStr;
+use std::{fmt::{Display, Formatter}, str::FromStr};
 
 use arm_toolchain::toolchain::ToolchainVersion;
 use cargo_metadata::{Metadata, Package, PackageId};
@@ -150,6 +150,14 @@ impl FromStr for ToolchainType {
         match &*s {
             "llvm" => Ok(Self::LLVM),
             _ => Err(BadFieldDataError::ToolchainTypeUnsupported { request: lower }),
+        }
+    }
+}
+
+impl Display for ToolchainType {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::LLVM => write!(f, "llvm"),
         }
     }
 }


### PR DESCRIPTION
Adds the ability to compile C code via the `arm-toolchain` crate. I refactored some of the build/upload process to achieve this.

From a user-level, you can now add the `toolchain` key to cargo-v5's settings. Toolchain configurations consist of a type and a version.

Currently LLVM is the only supported toolchain type, and its version must be one from <https://github.com/arm/arm-toolchain>'s releases.

```toml
[package.metadata.v5]
toolchain = "llvm-21.1.1"
# Somewhat flexible parsing:
toolchain = "LLVM-v20.0.1"
```

Any version of ARM's LLVM toolchain can technically be set, but it's not guaranteed to work if you choose something random.

When a toolchain is set, `cargo v5 build` will prompt the user to download it the next time they build. In this state, it is not possible to build with `cargo v5` unless the toolchain is installed. During a toolchain-enabled build, cargo-v5 will set the necessary environment variables so that `cc` and Rust can build C code and resolve the correct `libc`.

Users can also download the toolchain without building by running `cargo v5 toolchain install`. This PR doesn't include any other toolchain management commands, but it's installed in a way that's compatible with the https://github.com/vexide/arm-toolchain CLI.

These changes require no updates to user code, all configuration is done via environment variables and cargo CLI flags.